### PR TITLE
Use apache's archive for downloading solr releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Currently the only resource needed to configure the system is [init.pp](manifest
 ### `solr5`
 #### Parameters
 ##### package_url
-  Download url from the solr archive you'd like to install. Default: http://ftp.halifax.rwth-aachen.de/apache/lucene/solr/5.2.1/solr-5.2.1.tgz
+  Download url from the solr archive you'd like to install. Default: https://archive.apache.org/dist/lucene/solr//5.2.1/solr-5.2.1.tgz
 
 ##### package_version
 This paramter has to match the package version you'd like to install. Default: 5.2.1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 #
 # [*package_url*]
 #   download url from the solr archive you'd like to install.
-#   default: http://ftp.halifax.rwth-aachen.de/apache/lucene/solr/5.2.1/solr-5.2.1.tgz
+#   default: https://archive.apache.org/dist/lucene/solr/5.2.1/solr-5.2.1.tgz
 #
 # [*package_version*]
 #   this paramter has to match the package version you'd like to install
@@ -69,7 +69,7 @@
 # Install solr version 5.2.0
 #
 #   class { 'solr5':
-#       package_url => 'http://ftp.halifax.rwth-aachen.de/apache/lucene/solr/5.2.0/solr-5.2.0.tgz',
+#       package_url => 'https://archive.apache.org/dist/lucene/solr/5.2.0/solr-5.2.0.tgz',
 #       package_version => '5.2.0'
 #   }
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class solr5::params {
-    $package_mirror = 'ftp://ftp.halifax.rwth-aachen.de/apache'
+    $package_mirror = 'https://archive.apache.org/dist/lucene/solr/'
     $package_version = '5.2.1'
     $package_target_dir = '/tmp'
     $solr_install_dir = '/opt'


### PR DESCRIPTION
@rebuy-de/prp-puppet-solr5

The former used ftp mirror currently only has 5.5. and 6.0. Apparently
they removed all the other releases. Therefore using the apache archive.
